### PR TITLE
feat: Implement Series methods `array`, `empty`, `copy`, `to_numpy`, `to_list`, and `__iter__`

### DIFF
--- a/leanframe/core/series.py
+++ b/leanframe/core/series.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import ibis.expr.types as ibis_types
 import numpy as np
 import pandas as pd
-
 from leanframe.core.dtypes import convert_ibis_to_pandas
 
 
@@ -49,6 +48,11 @@ class Series:
         return self._data.to_pyarrow().to_numpy()
 
     @property
+    def array(self) -> "pd.api.extensions.ExtensionArray":
+        """Return the underlying data as a pandas ExtensionArray."""
+        return self.to_pandas().array
+
+    @property
     def shape(self) -> tuple[int, ...]:
         """Return a tuple of the shape of the underlying data."""
         return (self.size,)
@@ -72,6 +76,11 @@ class Series:
     def hasnans(self) -> bool:
         """Return True if there are any NaNs, False otherwise."""
         return self._data.isnull().any().to_pyarrow().as_py()
+
+    @property
+    def empty(self) -> bool:
+        """Return True if the Series is empty, False otherwise."""
+        return self.size == 0
     
     def __add__(self, other) -> Series:
         return Series(self._data + getattr(other, "_data", other))
@@ -85,8 +94,24 @@ class Series:
     def __rmul__(self, other) -> Series:
         return Series(getattr(other, "_data", other) * self._data)
 
+    def copy(self) -> Series:
+        """Return a copy of the Series."""
+        return Series(self._data)
+
     def to_pandas(self) -> pd.Series:
         """Convert to a pandas Series."""
         return self._data.to_pyarrow().to_pandas(
             types_mapper=lambda type_: pd.ArrowDtype(type_)
         )
+
+    def to_numpy(self) -> np.ndarray:
+        """Return a numpy representation of the Series."""
+        return self.values
+
+    def to_list(self) -> list:
+        """Return a list of the values."""
+        return self.to_pandas().to_list()
+
+    def __iter__(self):
+        """Return an iterator of the values."""
+        return iter(self.to_list())

--- a/tests/unit/test_series.py
+++ b/tests/unit/test_series.py
@@ -62,9 +62,25 @@ def test_series_hasnans(series_for_properties):
     assert series_float.hasnans
 
 
+def test_series_empty(session):
+    df_pd = pd.DataFrame({"col1": [1, 2, 3]})
+    df_lf = session.DataFrame(df_pd)
+    assert not df_lf["col1"].empty
+
+    df_pd_empty = pd.DataFrame({"col1": []})
+    df_lf_empty = session.DataFrame(df_pd_empty)
+    assert df_lf_empty["col1"].empty
+
+
 def test_series_values(series_for_properties):
     series_int, series_float = series_for_properties
     np.testing.assert_array_equal(series_int.values, np.array([1, 2, 3]))
+
+
+def test_series_array(series_for_properties):
+    series_int, series_float = series_for_properties
+    expected_array = pd.array([1, 2, 3], dtype=pd.ArrowDtype(pa.int64()))
+    pd.testing.assert_extension_array_equal(series_int.array, expected_array)
 
 
 def test_series_nbytes(series_for_properties):
@@ -171,6 +187,30 @@ def test_series_arithmetic_scalar(session, op, other, expected_data):
         expected_series,
         check_names=False,
     )
+
+
+def test_series_copy(session):
+    df_pd = pd.DataFrame({"col1": [1, 2, 3]})
+    df_lf = session.DataFrame(df_pd)
+    series = df_lf["col1"]
+    series_copy = series.copy()
+    assert series is not series_copy
+    assert series._data is series_copy._data
+
+
+def test_series_to_numpy(series_for_properties):
+    series_int, series_float = series_for_properties
+    np.testing.assert_array_equal(series_int.to_numpy(), np.array([1, 2, 3]))
+
+
+def test_series_to_list(series_for_properties):
+    series_int, series_float = series_for_properties
+    assert series_int.to_list() == [1, 2, 3]
+
+
+def test_series_iter(series_for_properties):
+    series_int, series_float = series_for_properties
+    assert list(iter(series_int)) == [1, 2, 3]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This change implements six new methods for the `leanframe.core.series.Series` class: `array`, `empty`, `copy`, `to_numpy`, `to_list`, and `__iter__`.

These methods are implemented to be compatible with the pandas API, as specified in `specs/2025-09-16-series-methods.md`.

Unit tests have been added for each new method to ensure correctness.