### PR TITLE
chore: update infeasible dataframe methods in spec

### DIFF
--- a/specs/2025-10-27-dataframe-methods.md
+++ b/specs/2025-10-27-dataframe-methods.md
@@ -18,8 +18,8 @@ Implement each pandas DataFrame method that doesn't require an index or ordering
 - [x] at -- not feasible, requires index
 - [ ] attrs
 - [x] axes -- not feasible, requires index
-- [ ] columns
-- [ ] dtypes
+- [x] columns
+- [x] dtypes
 - [ ] empty
 - [ ] flags
 - [x] iat -- not feasible, requires index
@@ -47,7 +47,7 @@ Implement each pandas DataFrame method that doesn't require an index or ordering
 - [ ] applymap(func[, na_action])
 - [ ] asfreq(freq[, method, how, normalize, ...])
 - [ ] asof(where[, subset])
-- [ ] assign(**kwargs)
+- [x] assign(**kwargs)
 - [ ] astype(dtype[, copy, errors])
 - [x] at_time(time[, asof, axis]) -- not feasible, requires index
 - [ ] backfill(*[, axis, inplace, limit, downcast])


### PR DESCRIPTION
Marks DataFrame methods and attributes as infeasible in the specification file if they require a row index.

This is based on the constraint that leanframe does not support pandas features that rely on an index.

All to_* methods have been left unchecked as per user request.