### PR TITLE
Refactor Session.col to standalone function

### DIFF
--- a/leanframe/__init__.py
+++ b/leanframe/__init__.py
@@ -15,6 +15,7 @@
 """LeanFrame provides a DataFrame API for BigQuery."""
 
 from leanframe.core.session import Session
+from leanframe.core.expression import col
 from leanframe.core.frame import DataFrameHandler
 from leanframe.core.nested_handler import NestedHandler
 from leanframe.version import __version__
@@ -22,6 +23,7 @@ from leanframe.version import __version__
 __all__ = [
     "__version__",
     "Session",
+    "col",
     "DataFrameHandler",
     "NestedHandler",
 ]

--- a/leanframe/core/expression.py
+++ b/leanframe/core/expression.py
@@ -16,7 +16,13 @@
 
 from __future__ import annotations
 
+import ibis
 import ibis.expr.types as ibis_types
+
+
+def col(name: str) -> Expression:
+    """Return a new expression object which is a deferred series."""
+    return Expression(ibis.deferred[name])
 
 
 class Expression:

--- a/leanframe/core/session.py
+++ b/leanframe/core/session.py
@@ -22,6 +22,7 @@ import ibis
 import ibis.expr.types as ibis_types
 import pandas
 
+from leanframe.core.expression import col
 
 _ALPHABET = "abcdefghijklmnopqrstufwxyz"
 
@@ -67,8 +68,4 @@ class Session:
                 f"DataFrame constructor doesn't support {type(data)} data yet."
             )
 
-    def col(self, name: str):
-        """Return a new expression object which is a deferred series."""
-        import leanframe.core.expression
-
-        return leanframe.core.expression.Expression(ibis.deferred[name])
+    col = staticmethod(col)

--- a/tests/unit/test_expression_col.py
+++ b/tests/unit/test_expression_col.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Google LLC, LeanFrame Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for standalone col and aliases."""
+
+import ibis
+import leanframe
+from leanframe.core.session import Session
+from leanframe.core.expression import Expression, col
+
+def test_col_standalone():
+    """Verify col() works as a standalone function."""
+    expr = col('a')
+    assert isinstance(expr, Expression)
+
+def test_col_session_static():
+    """Verify Session.col() works as a static method."""
+    expr = Session.col('a')
+    assert isinstance(expr, Expression)
+
+def test_col_session_instance():
+    """Verify session.col() works as an instance method (compatibility)."""
+    # Use sqlite backend as dummy
+    backend = ibis.sqlite.connect()
+    session = Session(backend)
+
+    expr = session.col('a')
+    assert isinstance(expr, Expression)
+
+def test_col_package_alias():
+    """Verify leanframe.col is available."""
+    expr = leanframe.col('a')
+    assert isinstance(expr, Expression)


### PR DESCRIPTION
Refactored `col` method to be a standalone function in `leanframe/core/expression.py` and exposed it in `leanframe` package. Maintained backward compatibility by aliasing it as a static method in `Session`. Added unit tests.

---
*PR created automatically by Jules for task [12199514612312728493](https://jules.google.com/task/12199514612312728493) started by @tswast*